### PR TITLE
Add cross-platform setup scripts and tooling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+node_modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  setup:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run installer (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          ./install-tools.ps1 -Yes
+      - name: Run installer (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          chmod +x install-tools.sh
+          sudo ./install-tools.sh --yes

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "roblox-ts.vscode-roblox-ts",
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "Kampfkarren.selene-vscode"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.formatOnSave": true,
+  "files.eol": "\n"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && \
+    apt-get install -y curl wget unzip git nodejs npm rustc cargo && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g roblox-ts eslint prettier
+
+RUN curl -L https://github.com/argon-rbx/argon/releases/download/2.0.25/argon-2.0.25-linux-x86_64.zip -o argon.zip \
+    && unzip argon.zip \
+    && mv argon /usr/local/bin/argon \
+    && rm argon.zip
+
+RUN curl -L https://github.com/UpliftGames/wally/releases/download/v0.3.2/wally-v0.3.2-linux.zip -o wally.zip \
+    && unzip wally.zip \
+    && mv wally /usr/local/bin/wally \
+    && rm wally.zip
+
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -1,18 +1,44 @@
-# 🔧 Cryptverse Studio - Windows Installer 
+# 🔧 Cryptverse Studio Installer
 
-Welcome to the official Cryptverse Studio Windows Installer. This script sets up all the essential tools and configurations required for our team development environment on a Windows machine.
+Scripts for bootstrapping the Cryptverse Studio development environment on Windows and macOS.
 
----
+## Windows
 
-## 🚀 Getting Started
-
-To install all necessary tools and dependencies:
-
-### 🪟 Step 1: Open PowerShell as Administrator
-
-> 💡 **Important:** You must run this script with administrative privileges to install system-wide tools properly.
-
-### 🔗 Step 2: Run the Installation Command
+Run the installer from an elevated PowerShell prompt:
 
 ```powershell
 iwr -useb https://raw.githubusercontent.com/Ecliptorhize/Cryptverse-Studio-Installer-Windows/refs/heads/main/install-tools.ps1 | iex
+```
+
+Non‑interactive usage:
+
+```powershell
+./install-tools.ps1 -Yes
+```
+
+## macOS
+
+Ensure [Homebrew](https://brew.sh/) is installed, then execute:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Ecliptorhize/Cryptverse-Studio-Installer-Windows/refs/heads/main/install-tools.sh | bash
+```
+
+Or run the script locally:
+
+```bash
+chmod +x install-tools.sh
+./install-tools.sh --yes
+```
+
+## Docker
+
+A basic development image is available:
+
+```bash
+docker build -t cryptverse-env .
+```
+
+## Development
+
+Recommended editor settings and extensions are provided in the `.vscode` directory. Continuous integration tests run on Windows and macOS via GitHub Actions.

--- a/install-tools.ps1
+++ b/install-tools.ps1
@@ -1,4 +1,8 @@
 # Cryptverse Studio Installer (PowerShell Version)
+param(
+    [switch]$Yes
+)
+
 Clear-Host
 Write-Host ""
 Write-Host "_________                        __                                       _________ __            .___.__        "
@@ -27,10 +31,12 @@ try {
 # ┌──────────────┐
 # │ Confirmation │
 # └──────────────┘
-$confirm = Read-Host "This will install all tools for Argon/Roblox dev. Continue? (y/n)"
-if ($confirm -ne "y") {
-    Write-Host "Cancelled."
-    exit
+if (-not $Yes) {
+    $confirm = Read-Host "This will install all tools for Argon/Roblox dev. Continue? (y/n)"
+    if ($confirm -ne "y") {
+        Write-Host "Cancelled."
+        exit
+    }
 }
 
 # ┌─────────────────────┐
@@ -58,7 +64,7 @@ npm install -g roblox-ts
 # │ Argon CLI  │
 # └────────────┘
 Write-Host "Installing Argon CLI..."
-Invoke-WebRequest -Uri "https://github.com/argon-rbx/argon/releases/download/2.0.24/argon-2.0.24-windows-x86_64.zip" -OutFile "argon.zip"
+Invoke-WebRequest -Uri "https://github.com/argon-rbx/argon/releases/download/2.0.25/argon-2.0.25-windows-x86_64.zip" -OutFile "argon.zip"
 Expand-Archive -Path "argon.zip" -DestinationPath "argon-unpacked" -Force
 Move-Item "argon-unpacked\argon.exe" "C:\ProgramData\chocolatey\bin\argon.exe" -Force
 Remove-Item "argon.zip", "argon-unpacked" -Recurse -Force

--- a/install-tools.sh
+++ b/install-tools.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Cryptverse Studio Installer (macOS/Linux Version)
+
+printf '\nChecking internet connection...\n'
+if ! curl -s --head https://www.google.com >/dev/null; then
+  echo "No internet connection. Please connect and try again."
+  exit 1
+fi
+printf 'Internet OK\n'
+
+if [[ "${1:-}" != "--yes" ]]; then
+  read -rp "This will install all tools for Argon/Roblox dev. Continue? (y/n) " confirm
+  if [[ $confirm != "y" ]]; then
+    echo "Cancelled."
+    exit 0
+  fi
+fi
+
+if ! command -v brew >/dev/null; then
+  echo "Homebrew is required. Install it from https://brew.sh/ and re-run."
+  exit 1
+fi
+
+brew install node git wget unzip rust
+
+npm install -g roblox-ts
+
+printf 'Installing Argon CLI...\n'
+curl -L https://github.com/argon-rbx/argon/releases/download/2.0.25/argon-2.0.25-macos-x86_64.zip -o argon.zip
+unzip -o argon.zip >/dev/null
+sudo mv argon /usr/local/bin/argon
+rm -f argon.zip
+
+printf 'Installing Wally...\n'
+curl -L https://github.com/UpliftGames/wally/releases/download/v0.3.2/wally-v0.3.2-macos.zip -o wally.zip
+unzip -o wally.zip >/dev/null
+sudo mv wally /usr/local/bin/wally
+rm -f wally.zip
+
+npm install -g eslint prettier
+
+echo "All tools installed. You're ready!"


### PR DESCRIPTION
## Summary
- Support non-interactive Windows installs and add macOS script
- Provide Dockerfile, editor settings, and GitHub Actions CI for Windows/macOS
- Document cross-platform usage in README

## Testing
- `bash -n install-tools.sh`
- `shellcheck install-tools.sh`
- `apt-get install -y shellcheck`

------
https://chatgpt.com/codex/tasks/task_e_68a6adc0c5b88322bf2884220da7f6fc